### PR TITLE
Add Manage Session view

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,6 +6,8 @@ const cors = require('cors');
 const { Pool } = require('pg');
 const axios = require('axios');
 const jwt = require('jsonwebtoken');
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 app.use(cors());
@@ -86,6 +88,26 @@ app.put('/sessions/:sessionId/webhook', async (req, res) => {
   res.json({ session: result.rows[0] });
 });
 
+app.put('/sessions/:sessionId', async (req, res) => {
+  const { sessionId } = req.params;
+  const { newSessionId, webhookUrl } = req.body;
+  if (!newSessionId) return res.status(400).json({ error: "newSessionId required" });
+  if (!isValidSessionId(sessionId) || !isValidSessionId(newSessionId)) {
+    return res.status(400).json({ error: "SessionId hanya boleh huruf, angka, _ atau -" });
+  }
+  try {
+    const q = `UPDATE wa_sessions SET session_id=$1, webhook_url=$2, updated_at=NOW() WHERE session_id=$3 RETURNING *`;
+    const result = await pool.query(q, [newSessionId, webhookUrl, sessionId]);
+    if (sessions[sessionId]) {
+      sessions[newSessionId] = sessions[sessionId];
+      delete sessions[sessionId];
+    }
+    res.json({ session: result.rows[0] });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.delete('/sessions/:sessionId', async (req, res) => {
   const { sessionId } = req.params;
   if (!isValidSessionId(sessionId)) return res.status(400).json({ error: "SessionId hanya boleh huruf, angka, _ atau -" });
@@ -94,6 +116,18 @@ app.delete('/sessions/:sessionId', async (req, res) => {
     sessions[sessionId].client.destroy();
     delete sessions[sessionId];
   }
+  res.json({ success: true });
+});
+
+app.post('/sessions/:sessionId/reset', async (req, res) => {
+  const { sessionId } = req.params;
+  if (!isValidSessionId(sessionId)) return res.status(400).json({ error: "SessionId hanya boleh huruf, angka, _ atau -" });
+  if (sessions[sessionId]) {
+    try { await sessions[sessionId].client.destroy(); } catch {}
+    delete sessions[sessionId];
+  }
+  const dir = path.join('.wwebjs_auth', sessionId);
+  fs.rmSync(dir, { recursive: true, force: true });
   res.json({ success: true });
 });
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -178,6 +178,10 @@ body, html {
   color: #2176ff;
   font-weight: 600;
 }
+.table-scroll {
+  max-height: 360px;
+  overflow-y: auto;
+}
 @media (max-width: 1100px) {
   .dashboard-flex { flex-direction: column; gap: 14px;}
   .main-content { padding: 12px;}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,31 +1,7 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
-import axios from "axios";
 import ManageSessions from "./components/ManageSessions";
-const API = "http://localhost:3001";
-
-// === Utility axios instance dengan Interceptor 401 ===
-const api = axios.create({ baseURL: API });
-api.interceptors.request.use(
-  config => {
-    const token = localStorage.getItem("token");
-    if (token) config.headers.Authorization = "Bearer " + token;
-    return config;
-  },
-  error => Promise.reject(error)
-);
-
-// ==== Interceptor RESPONSE (Logout jika 401) ====
-api.interceptors.response.use(
-  res => res,
-  err => {
-    if (err.response && err.response.status === 401) {
-      localStorage.removeItem("token");
-      window.location.reload(); // Paksa reload, langsung ke halaman login
-    }
-    return Promise.reject(err);
-  }
-);
+import api from "./api";
 
 // === LOGIN COMPONENT ===
 function Login({ onLogin }) {
@@ -37,7 +13,7 @@ function Login({ onLogin }) {
     e.preventDefault();
     setErr(""); setLoading(true);
     try {
-      const res = await axios.post(API + "/login", { username, password });
+      const res = await api.post("/login", { username, password });
       localStorage.setItem("token", res.data.token);
       onLogin();
     } catch {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
 import axios from "axios";
+import ManageSessions from "./components/ManageSessions";
 const API = "http://localhost:3001";
 
 // === Utility axios instance dengan Interceptor 401 ===
@@ -220,8 +221,9 @@ function ChatHistory({ sessionId }) {
   return (
     <div className="history-card">
       <h3 className="section-title">Riwayat Pesan</h3>
-      <table className="msg-table">
-        <thead>
+      <div className="table-scroll">
+        <table className="msg-table">
+          <thead>
           <tr>
             <th>Tipe</th>
             <th>Pengirim</th>
@@ -245,7 +247,8 @@ function ChatHistory({ sessionId }) {
             </tr>
           ))}
         </tbody>
-      </table>
+        </table>
+      </div>
     </div>
   );
 }
@@ -257,6 +260,7 @@ function App() {
   const [sessionId, setSessionId] = useState("");
   const [waStatus, setWaStatus] = useState("");
   const [waInfo, setWaInfo] = useState(null);
+  const [menu, setMenu] = useState("dashboard");
 
   useEffect(() => {
     if (loggedIn) reloadSessions();
@@ -298,7 +302,18 @@ function App() {
       <aside className="sidebar">
         <div className="sidebar-logo">Clevio<span>PRO</span></div>
         <nav>
-          <div className="sidebar-item active">Dashboard</div>
+          <div
+            className={`sidebar-item ${menu === "dashboard" ? "active" : ""}`}
+            onClick={() => setMenu("dashboard")}
+          >
+            Dashboard
+          </div>
+          <div
+            className={`sidebar-item ${menu === "manage" ? "active" : ""}`}
+            onClick={() => setMenu("manage")}
+          >
+            Manage Session
+          </div>
         </nav>
       </aside>
       <div className="main-content">
@@ -331,20 +346,27 @@ function App() {
             >Logout</button>
           </div>
         </header>
-        <div className="dashboard-flex">
+        {menu === "dashboard" && (
+          <div className="dashboard-flex">
+            <div className="dashboard-section">
+              <SessionManager
+                sessionId={sessionId}
+                setSessionId={setSessionId}
+                sessions={sessions}
+                reloadSessions={reloadSessions}
+              />
+              <QRScanner sessionId={sessionId} />
+            </div>
+            <div className="dashboard-section flex-grow">
+              <ChatHistory sessionId={sessionId} />
+            </div>
+          </div>
+        )}
+        {menu === "manage" && (
           <div className="dashboard-section">
-            <SessionManager
-              sessionId={sessionId}
-              setSessionId={setSessionId}
-              sessions={sessions}
-              reloadSessions={reloadSessions}
-            />
-            <QRScanner sessionId={sessionId} />
+            <ManageSessions />
           </div>
-          <div className="dashboard-section flex-grow">
-            <ChatHistory sessionId={sessionId} />
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,26 @@
+import axios from "axios";
+export const API_URL = "http://localhost:3001";
+
+const api = axios.create({ baseURL: API_URL });
+
+api.interceptors.request.use(
+  config => {
+    const token = localStorage.getItem("token");
+    if (token) config.headers.Authorization = "Bearer " + token;
+    return config;
+  },
+  error => Promise.reject(error)
+);
+
+api.interceptors.response.use(
+  res => res,
+  err => {
+    if (err.response && err.response.status === 401) {
+      localStorage.removeItem("token");
+      window.location.reload();
+    }
+    return Promise.reject(err);
+  }
+);
+
+export default api;

--- a/frontend/src/components/ManageSessions.js
+++ b/frontend/src/components/ManageSessions.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
-const API = "http://localhost:3001";
+import api from "../api";
 
 const ManageSessions = () => {
   const [sessions, setSessions] = useState([]);
@@ -9,7 +8,7 @@ const ManageSessions = () => {
   const [loading, setLoading] = useState(false);
 
   const loadSessions = () => {
-    axios.get(`${API}/sessions`).then(res => setSessions(res.data.sessions || []));
+    api.get(`/sessions`).then(res => setSessions(res.data.sessions || []));
   };
 
   useEffect(() => { loadSessions(); }, []);
@@ -27,7 +26,7 @@ const ManageSessions = () => {
   const saveEdit = async () => {
     if (!editId) return;
     setLoading(true);
-    await axios.put(`${API}/sessions/${editId}`, {
+    await api.put(`/sessions/${editId}`, {
       newSessionId: form.session_id,
       webhookUrl: form.webhook_url
     });
@@ -37,13 +36,13 @@ const ManageSessions = () => {
   };
 
   const resetSession = async (id) => {
-    await axios.post(`${API}/sessions/${id}/reset`);
+    await api.post(`/sessions/${id}/reset`);
     loadSessions();
   };
 
   const deleteSession = async (id) => {
     if (!window.confirm("Hapus session ini?")) return;
-    await axios.delete(`${API}/sessions/${id}`);
+    await api.delete(`/sessions/${id}`);
     loadSessions();
   };
 

--- a/frontend/src/components/ManageSessions.js
+++ b/frontend/src/components/ManageSessions.js
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+const API = "http://localhost:3001";
+
+const ManageSessions = () => {
+  const [sessions, setSessions] = useState([]);
+  const [editId, setEditId] = useState(null);
+  const [form, setForm] = useState({ session_id: "", webhook_url: "" });
+  const [loading, setLoading] = useState(false);
+
+  const loadSessions = () => {
+    axios.get(`${API}/sessions`).then(res => setSessions(res.data.sessions || []));
+  };
+
+  useEffect(() => { loadSessions(); }, []);
+
+  const startEdit = (sess) => {
+    setEditId(sess.session_id);
+    setForm({ session_id: sess.session_id, webhook_url: sess.webhook_url || "" });
+  };
+
+  const cancelEdit = () => {
+    setEditId(null);
+    setForm({ session_id: "", webhook_url: "" });
+  };
+
+  const saveEdit = async () => {
+    if (!editId) return;
+    setLoading(true);
+    await axios.put(`${API}/sessions/${editId}`, {
+      newSessionId: form.session_id,
+      webhookUrl: form.webhook_url
+    });
+    setLoading(false);
+    cancelEdit();
+    loadSessions();
+  };
+
+  const resetSession = async (id) => {
+    await axios.post(`${API}/sessions/${id}/reset`);
+    loadSessions();
+  };
+
+  const deleteSession = async (id) => {
+    if (!window.confirm("Hapus session ini?")) return;
+    await axios.delete(`${API}/sessions/${id}`);
+    loadSessions();
+  };
+
+  return (
+    <div>
+      <h2 className="section-title">Manage Session</h2>
+      <div className="table-scroll">
+        <table className="msg-table">
+          <thead>
+            <tr>
+              <th>Session</th>
+              <th>Webhook</th>
+              <th>Aksi</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.length === 0 && (
+              <tr>
+                <td colSpan={3} style={{ textAlign: "center" }}>Belum ada session</td>
+              </tr>
+            )}
+            {sessions.map(sess => (
+              editId === sess.session_id ? (
+                <tr key={sess.session_id}>
+                  <td>
+                    <input
+                      className="input-main"
+                      value={form.session_id}
+                      onChange={e => setForm({ ...form, session_id: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="input-main"
+                      value={form.webhook_url}
+                      onChange={e => setForm({ ...form, webhook_url: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <button className="btn-main" onClick={saveEdit} disabled={loading}>Simpan</button>
+                    <button className="btn-main" onClick={cancelEdit}>Batal</button>
+                  </td>
+                </tr>
+              ) : (
+                <tr key={sess.session_id}>
+                  <td>{sess.session_id}</td>
+                  <td>{sess.webhook_url || "-"}</td>
+                  <td>
+                    <button className="btn-main" onClick={() => resetSession(sess.session_id)}>Scan ulang</button>
+                    <button className="btn-main" onClick={() => startEdit(sess)}>Edit</button>
+                    <button className="btn-main" onClick={() => deleteSession(sess.session_id)}>Hapus</button>
+                  </td>
+                </tr>
+              )
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ManageSessions;
+


### PR DESCRIPTION
## Summary
- add ManageSessions component
- update dashboard UI to include Manage Session menu
- scroll chat history when too long
- extend backend API for session rename and reset

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError in react-scripts)*
- `npm test` in backend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882227b34148325bc8030cfb24cb76c